### PR TITLE
fix: :bug: Fix bug to fail fused layer norm cuda file build

### DIFF
--- a/oslo/torch/_C/csrc/includes/type_shim.h
+++ b/oslo/torch/_C/csrc/includes/type_shim.h
@@ -142,10 +142,14 @@
     }                                                                          \
     case at::ScalarType::BFloat16: {                                           \
       using scalar_t_out = at::BFloat16;                                       \
+      __VA_ARGS__;                                                             \
+      break;                                                                   \
+    }                                                                          \
     default:                                                                   \
       AT_ERROR(#NAME, " not implemented for '", toString(TYPEOUT), "'");       \
-    } break;                                                                   \
     }                                                                          \
+    break;                                                                     \
+  }                                                                            \
   case at::ScalarType::Half: {                                                 \
     using scalar_t_in = at::Half;                                              \
     using scalar_t_out = at::Half;                                             \


### PR DESCRIPTION
type_shim.h is fixed from working commits

## Fix fused_layer_norm build fail error
-

## Description

failed to pass test fused_layer_norm  functions
not because of cuda file but there was an error on type_shim.h

## Linked Issues

- resolved #00
