### PR TITLE
Add splitting bias for head

### DIFF
--- a/oslo/torch/nn/parallel/tensor_parallel/_parallel_1d/_wrapper.py
+++ b/oslo/torch/nn/parallel/tensor_parallel/_parallel_1d/_wrapper.py
@@ -299,6 +299,19 @@ class _TensorParallel1D(BaseTensorParallelWrapper):
                 gather_output=not is_oslo_model(self.module),
             )
         else:
+            world_size = self.parallel_context.get_world_size(ParallelMode.TENSOR_1D)
+            rank = self.parallel_context.get_local_rank(ParallelMode.TENSOR_1D)
+
+            if hasattr(module, "bias") and module.bias is not None:
+                if module.bias.dim() >= 1:
+                    bias_list = module.bias.data.chunk(world_size, dim=0)
+                    module.bias.data = bias_list[rank].contiguous()
+
+                    if hasattr(module.bias, "oslo_parallel"):
+                        module.bias.oslo_parallel[ParallelMode.TENSOR_1D] = rank
+                    else:
+                        module.bias.oslo_parallel = {ParallelMode.TENSOR_1D: rank}
+
             _update_module_arguments(
                 module=module,
                 parallel_context=self.parallel_context,

--- a/oslo/torch/nn/parallel/tensor_parallel/_parallel_2d/_wrapper.py
+++ b/oslo/torch/nn/parallel/tensor_parallel/_parallel_2d/_wrapper.py
@@ -410,6 +410,23 @@ class _TensorParallel2D(BaseTensorParallelWrapper):
             pipeline_parallel_size = self.parallel_context.get_world_size(
                 ParallelMode.PIPELINE
             )
+            if hasattr(module, "bias") and module.bias is not None:
+                if module.bias.dim() >= 1:
+                    bias_list = module.bias.data.chunk(summa_dim, dim=0)
+                    bias_list = [
+                        bias.chunk(summa_dim, dim=0) for bias in bias_list
+                    ]
+                    module.bias.data = bias_list[row_rank][col_rank].contiguous()
+
+                    if hasattr(module.bias, "oslo_parallel"):
+                        module.bias.oslo_parallel[ParallelMode.TENSOR_2D_ROW] = row_rank
+                        module.bias.oslo_parallel[ParallelMode.TENSOR_2D_COL] = col_rank
+                    else:
+                        module.bias.oslo_parallel = {
+                            ParallelMode.TENSOR_2D_ROW: row_rank,
+                            ParallelMode.TENSOR_2D_COL: col_rank,
+                        }
+                        
             _update_module_arguments(
                 module=module,
                 in_features=module.weight.size()[1],

--- a/oslo/torch/nn/parallel/tensor_parallel/_parallel_2d/_wrapper.py
+++ b/oslo/torch/nn/parallel/tensor_parallel/_parallel_2d/_wrapper.py
@@ -410,6 +410,7 @@ class _TensorParallel2D(BaseTensorParallelWrapper):
             pipeline_parallel_size = self.parallel_context.get_world_size(
                 ParallelMode.PIPELINE
             )
+            
             if hasattr(module, "bias") and module.bias is not None:
                 if module.bias.dim() >= 1:
                     bias_list = module.bias.data.chunk(summa_dim, dim=0)


### PR DESCRIPTION
- When embedding and output linear weights are tied, we still need to split bias.