### PR TITLE
Add OPT Model mapping

### DIFF
--- a/oslo/transformers/mapping_utils.py
+++ b/oslo/transformers/mapping_utils.py
@@ -125,6 +125,12 @@ class _TensorParallelMappingForHuggingFace(_ParallelMappingForHuggingFace):
             Update("embed_dim", "num_attention_heads"),
             Head("lm_head", "score"),
         ],
+        OPT=[
+            Column("q_proj", "k_proj", "v_proj", "fc1"),
+            Row("out_proj", "fc2"),
+            Update("embed_dim", "num_heads"),
+            Head("lm_head", "score"),
+        ],
         "Electra": [
             Column("query", "key", "value", "intermediate.dense"),
             Column(


### PR DESCRIPTION
## Title

- oslo v3 support OPT Model

## Description

-`parallelformers`에서 작업한 내용과 동일합니다. 현재 V2.0.1에서 수정해서 사용하면서 V3에 반영되길 바라며 추가 하였습니다.
- Add OPT model mapping
