### PR TITLE
fix local_world_size for slurm

### DIFF
--- a/oslo/torch/distributed/parallel_context.py
+++ b/oslo/torch/distributed/parallel_context.py
@@ -268,7 +268,7 @@ class ParallelContext(object):
         """
         rank = int(os.environ["SLURM_PROCID"])
         world_size = int(os.environ["SLURM_NPROCS"])
-        local_world_size = int(os.environ["SLURM_JOB_NUMNODES"])
+        local_world_size = int(os.environ["SLURM_NTASKS_PER_NODE"])
 
         return cls(
             rank=rank,


### PR DESCRIPTION
## Title

Change the way to get `local_world_size` for slurm

## Description

- `local_world_size` means the number of processes that are running on a node, not the number of nodes
- `SLURM_NTASKS_PER_NODE` does mean the number of tasks requested per node.
- `SLURM_JOB_NUMNODES` does not exist. `SLURM_JOB_NUM_NODES` is the total number of nodes in the job's resource allocation.
- reference: https://slurm.schedmd.com/sbatch.html
- This patch will resolve this error:
```
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cuda:2! (when checking argument for argument index in method wrapper__index_select)
```
